### PR TITLE
Fix before lockfile path

### DIFF
--- a/lib/bundler_diff/cli.rb
+++ b/lib/bundler_diff/cli.rb
@@ -38,7 +38,7 @@ module BundlerDiff
     end
 
     def before_lockfile
-      `git show #{commit}:#{file_name}`.tap do
+      `git show #{commit}:./#{file_name}`.tap do
         raise unless $?.success? # rubocop:disable Style/SpecialGlobalVars
       end
     end


### PR DESCRIPTION
After lockfile is read from current working directory.
So, before lockfile also should be the same.

`:Gemfile.lock` is a relative path from repository root directory.
`:./Gemfile.lock` is a relative path from current working directory.