### PR TITLE
Make it executable on any sub-directory

### DIFF
--- a/bundler-diff.gemspec
+++ b/bundler-diff.gemspec
@@ -22,10 +22,10 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
+  spec.add_dependency 'bundler', '~> 1.14'
   spec.add_dependency 'gems_comparator'
   spec.add_dependency 'parallel'
 
-  spec.add_development_dependency 'bundler', '~> 1.14'
   spec.add_development_dependency 'rake', '~> 10.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop', '0.56.0'

--- a/lib/bundler_diff/cli.rb
+++ b/lib/bundler_diff/cli.rb
@@ -38,7 +38,7 @@ module BundlerDiff
     end
 
     def before_lockfile
-      `git show #{commit}:#{file_name}`.tap do
+      `git show #{commit}:./#{file_name}`.tap do
         raise unless $?.success? # rubocop:disable Style/SpecialGlobalVars
       end
     end

--- a/lib/bundler_diff/cli.rb
+++ b/lib/bundler_diff/cli.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
+require 'bundler'
 require 'gems_comparator'
 require 'json'
 require 'optparse'
+require 'pathname'
 
 module BundlerDiff
   class CLI
@@ -33,18 +35,18 @@ module BundlerDiff
 
     private
 
-    def file_name
-      @file_name ||= File.exist?('gems.locked') ? 'gems.locked' : 'Gemfile.lock'
+    def file_path
+      @file_path ||= Bundler.default_lockfile.relative_path_from(Pathname.pwd)
     end
 
     def before_lockfile
-      `git show #{commit}:./#{file_name}`.tap do
+      `git show #{commit}:#{file_path}`.tap do
         raise unless $?.success? # rubocop:disable Style/SpecialGlobalVars
       end
     end
 
     def after_lockfile
-      File.read(file_name)
+      File.read(file_path)
     end
 
     def parse_options!


### PR DESCRIPTION
Hi, @sinsoku 

I changed the `bundle diff` command to be able to executable on any sub-directory of git repository.

This includes #3 