### PR TITLE
Add `./` prefix to before lockfile path

### DIFF
--- a/lib/bundler_diff/cli.rb
+++ b/lib/bundler_diff/cli.rb
@@ -40,7 +40,7 @@ module BundlerDiff
     end
 
     def before_lockfile
-      `git show #{commit}:#{file_path}`.tap do
+      `git show #{commit}:./#{file_path}`.tap do
         raise unless $?.success? # rubocop:disable Style/SpecialGlobalVars
       end
     end


### PR DESCRIPTION
Hi, @sinsoku 

I made a bitly mistake in PR #4.
`Pathname#relative_path_from` is returned without `./` prefix.
This make a problem when lockfile is located in other than repository root.
