### PR TITLE
Use markdown style for compare_url

### DIFF
--- a/lib/bundler_diff/formatter/md_table.rb
+++ b/lib/bundler_diff/formatter/md_table.rb
@@ -18,7 +18,7 @@ module BundlerDiff
       def render_row(gem)
         name = format_name(gem)
         before, after = gem.fetch_values(:before, :after)
-        compare_url = "#{icon_for(gem)} #{gem[:compare_url]}"
+        compare_url = "#{icon_for(gem)} #{url_for(gem)}"
 
         format TEMPLATE, name, before, after, compare_url
       end
@@ -42,6 +42,18 @@ module BundlerDiff
           ':x:'
         else
           ':bug:'
+        end
+      end
+
+      def url_for(gem)
+        case icon_for(gem)
+        when ':warning:', ':white_check_mark:'
+          before, after = gem.fetch_values(:before, :after)
+          "[#{gem[:name]}@ #{before}...#{after}](#{gem[:compare_url]})"
+        when ':bug:'
+          gem[:compare_url]
+        else
+          ''
         end
       end
     end

--- a/spec/bundler_diff/formatter/md_table_spec.rb
+++ b/spec/bundler_diff/formatter/md_table_spec.rb
@@ -42,9 +42,9 @@ module BundlerDiff
           | gem | before | after | compare |
           |---|---|---|---|
           | error_gem | 0.1.0 | 0.2.0 | :bug: RuntimeError |
-          | [rake](#{RAKE_URL}) | 11.3.0 | 12.0.0 | :white_check_mark: #{RAKE_URL} |
+          | [rake](#{RAKE_URL}) | 11.3.0 | 12.0.0 | :white_check_mark: [rake@ 11.3.0...12.0.0](#{RAKE_URL}) |
           | rspec | 3.5.0 |  | :x:  |
-          | warning_gem | 0.1.0 | 0.2.0 | :warning: #{WARNING_URL} |
+          | warning_gem | 0.1.0 | 0.2.0 | :warning: [warning_gem@ 0.1.0...0.2.0](#{WARNING_URL}) |
         TABLE
         expect(formatter.render(gems)).to eq expected
       end


### PR DESCRIPTION
Hi, @sinsoku

# Background
Github Enterprise does not make shorten diff-link of source code hosted at Github.
Thus `md_table` shows like this 😇 

![image](https://user-images.githubusercontent.com/22689/49698859-1a405c00-fc0d-11e8-99bf-4002f3b92176.png)


# Description
This PR changes `compare_url` by markdown style 
when gem is marked as `:warning:` or `:white_check_mark:`.

And `Background`'s table is changed like this.

![image](https://user-images.githubusercontent.com/22689/49698843-e06f5580-fc0c-11e8-9df4-c03c8d3d5f7d.png)
