### PR TITLE
Remove emojis for common cases

### DIFF
--- a/lib/bundler_diff/formatter/md_table.rb
+++ b/lib/bundler_diff/formatter/md_table.rb
@@ -18,7 +18,7 @@ module BundlerDiff
       def render_row(gem)
         name = format_name(gem)
         before, after = gem.fetch_values(:before, :after)
-        compare_url = "#{icon_for(gem)} #{url_for(gem)}"
+        compare_url = [icon_for(gem), url_for(gem)].compact.join ' '
 
         format TEMPLATE, name, before, after, compare_url
       end
@@ -32,28 +32,39 @@ module BundlerDiff
         end
       end
 
-      def icon_for(gem)
+      def state_for(gem)
         case gem[:compare_url]
         when /master$/
-          ':warning:'
+          :warning
         when URI::DEFAULT_PARSER.make_regexp
-          ':white_check_mark:'
+          :success
         when nil
-          ':x:'
+          :failure
+        else
+          :error
+        end
+      end
+
+      def icon_for(gem)
+        case state_for(gem)
+        when :warning
+          ':warning:'
+        when :success
+          nil
+        when :failure
+          'Failed to find projects GitHub URL'
         else
           ':bug:'
         end
       end
 
       def url_for(gem)
-        case icon_for(gem)
-        when ':warning:', ':white_check_mark:'
+        case state_for(gem)
+        when :warning, :success
           before, after = gem.fetch_values(:before, :after)
           "[#{gem[:name]}@ #{before}...#{after}](#{gem[:compare_url]})"
-        when ':bug:'
+        when :error
           gem[:compare_url]
-        else
-          ''
         end
       end
     end

--- a/spec/bundler_diff/formatter/md_table_spec.rb
+++ b/spec/bundler_diff/formatter/md_table_spec.rb
@@ -42,8 +42,8 @@ module BundlerDiff
           | gem | before | after | compare |
           |---|---|---|---|
           | error_gem | 0.1.0 | 0.2.0 | :bug: RuntimeError |
-          | [rake](#{RAKE_URL}) | 11.3.0 | 12.0.0 | :white_check_mark: [rake@ 11.3.0...12.0.0](#{RAKE_URL}) |
-          | rspec | 3.5.0 |  | :x:  |
+          | [rake](#{RAKE_URL}) | 11.3.0 | 12.0.0 | [rake@ 11.3.0...12.0.0](#{RAKE_URL}) |
+          | rspec | 3.5.0 |  | Failed to find projects GitHub URL |
           | warning_gem | 0.1.0 | 0.2.0 | :warning: [warning_gem@ 0.1.0...0.2.0](#{WARNING_URL}) |
         TABLE
         expect(formatter.render(gems)).to eq expected


### PR DESCRIPTION
The markdown mode is too emoji heavy for common cases, after enabling this on some projects at work the first 2 questions i was asked were about what the emoji tick and cross mean, people assume it's related to some check that was performed on the gem.

| gem | before | after | compare |
|---|---|---|---|
| ddtrace | 0.18.1 | 0.18.2 | :x:  |
| i18n | 1.4.0 | 1.5.1 | :x:  |
| [nokogiri](https://github.com/sparklemotion/nokogiri) | 1.9.1 | 1.10.0 | :white_check_mark: [nokogiri@ 1.9.1...1.10.0](https://github.com/sparklemotion/nokogiri/compare/v1.9.1...v1.10.0) |

Remove the check mark from success, since it is already clear that the script
worked since it rendered the compare link. The green tick is confusing because
we haven't tested or checked anything, but it looks like the gem is approved?

Remove the red x from failures and replace with an error message, the red X
assumes that the developer has some understanding of what the red X means, but
without any context it's easy to assume the Gem has failed a check.  But it
could just be that the gem isn't hosted on Github.

New output would look like

| gem | before | after | compare |
|---|---|---|---|
| ddtrace | 0.18.1 | 0.18.2 | Failed to find projects GitHub URL  |
| i18n | 1.4.0 | 1.5.1 | Failed to find projects GitHub URL  |
| [nokogiri](https://github.com/sparklemotion/nokogiri) | 1.9.1 | 1.10.0 |  [nokogiri@ 1.9.1...1.10.0](https://github.com/sparklemotion/nokogiri/compare/v1.9.1...v1.10.0) |