### PR TITLE
Relax bundler dependency

### DIFF
--- a/bundler-diff.gemspec
+++ b/bundler-diff.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'bundler', '~> 1.14'
+  spec.add_dependency 'bundler', '~> 2.0'
   spec.add_dependency 'gems_comparator'
   spec.add_dependency 'parallel'
 


### PR DESCRIPTION
Bundler 2 has been released.
Would you be okay to relax dependency to bundler in this timing?

Tests are all passed off, I think this gives us some sense that we can use this gem safely together with bundler 2.